### PR TITLE
Amazon購入履歴抽出Chrome拡張機能の実装と改善

### DIFF
--- a/chrome-extension-amazon-purchase-history/README.md
+++ b/chrome-extension-amazon-purchase-history/README.md
@@ -1,0 +1,99 @@
+# Amazon Purchase History Extractor Chrome Extension
+
+Amazon（.com, .co.jpなど）のユーザーの購入履歴を抽出するChrome Extensionです。
+
+## 機能
+
+- Amazon注文履歴ページから購入情報を自動抽出
+- 複数のAmazonドメインに対応（.com, .co.jp, .de, .fr, .it, .es, .co.uk）
+- 抽出データの表示・管理
+- JSONファイルとしてのデータエクスポート
+- 重複データの自動除去
+- リアルタイムでの抽出状況表示
+
+## インストール方法
+
+1. Chromeを開く
+2. `chrome://extensions/` にアクセス
+3. 右上の「デベロッパーモード」を有効にする
+4. 「パッケージ化されていない拡張機能を読み込む」をクリック
+5. このディレクトリ（`chrome-extension-amazon-purchase-history`）を選択
+
+## 使用方法
+
+1. **Amazon注文履歴ページに移動**
+   - Amazon.com: https://www.amazon.com/gp/your-account/order-history
+   - Amazon.co.jp: https://www.amazon.co.jp/gp/your-account/order-history
+
+2. **拡張機能を起動**
+   - ブラウザのツールバーにある拡張機能アイコンをクリック
+
+3. **購入履歴を抽出**
+   - 「購入履歴を抽出」ボタンをクリック
+   - 複数ページがある場合は、各ページで実行
+
+4. **データの確認・エクスポート**
+   - 「抽出データを表示」で内容確認
+   - 「JSONでエクスポート」でファイル保存
+
+## 抽出される情報
+
+- 注文ID
+- 注文日
+- 商品名
+- 商品URL
+- 商品画像URL
+- 価格情報
+- 配送状況
+- 抽出日時
+
+## ファイル構成
+
+```
+chrome-extension-amazon-purchase-history/
+├── manifest.json      # 拡張機能の設定ファイル
+├── popup.html         # ポップアップUIのHTML
+├── popup.css          # ポップアップのスタイル
+├── popup.js           # ポップアップの動作制御
+├── content.js         # Amazonページでの抽出処理
+├── background.js      # バックグラウンド処理
+└── README.md          # このファイル
+```
+
+## 対応サイト
+
+- Amazon.com (アメリカ)
+- Amazon.co.jp (日本)
+- Amazon.de (ドイツ)
+- Amazon.fr (フランス)
+- Amazon.it (イタリア)
+- Amazon.es (スペイン)
+- Amazon.co.uk (イギリス)
+
+## 注意事項
+
+- この拡張機能は個人の購入履歴データを扱います
+- データは Browser のローカルストレージに保存されます
+- Amazonの利用規約に従って使用してください
+- ページの構造変更により動作しない場合があります
+
+## トラブルシューティング
+
+### 抽出できない場合
+1. Amazon注文履歴ページにいることを確認
+2. ページが完全に読み込まれるまで待機
+3. 拡張機能を再読み込み
+
+### データが表示されない場合
+1. 「抽出データを表示」ボタンをクリック
+2. ストレージをクリアして再実行
+
+## プライバシー
+
+- 抽出したデータはユーザーのブラウザ内にのみ保存されます
+- 外部サーバーへのデータ送信は行いません
+- データの削除は「データをクリア」ボタンで可能です
+
+## 開発者情報
+
+このChrome Extensionは学習・研究目的で作成されています。商用利用の際はAmazonの利用規約をご確認ください。

--- a/chrome-extension-amazon-purchase-history/background.js
+++ b/chrome-extension-amazon-purchase-history/background.js
@@ -1,0 +1,102 @@
+// Background script for Amazon Purchase History Extractor
+
+chrome.runtime.onInstalled.addListener(() => {
+  console.log('Amazon Purchase History Extractor installed');
+
+  // コンテキストメニューの追加
+  try {
+    chrome.contextMenus.create({
+      id: 'extract-amazon-history',
+      title: 'Amazon購入履歴を抽出',
+      contexts: ['page'],
+      documentUrlPatterns: ['https://*.amazon.com/*', 'https://*.amazon.co.jp/*']
+    });
+  } catch (error) {
+    console.log('Context menu creation failed:', error);
+  }
+});
+
+// メッセージハンドリング
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.action === 'extraction_complete') {
+    // 抽出完了通知をポップアップに転送
+    chrome.runtime.sendMessage({
+      action: 'extraction_complete',
+      ordersCount: request.ordersCount,
+      totalOrders: request.totalOrders
+    }).catch(() => {
+      // ポップアップが開いていない場合はエラーを無視
+    });
+  }
+
+  if (request.action === 'get_storage_data') {
+    chrome.storage.local.get(['amazonOrders', 'lastExtracted'], (result) => {
+      sendResponse(result);
+    });
+    return true; // 非同期レスポンスを示す
+  }
+
+  if (request.action === 'clear_storage') {
+    chrome.storage.local.clear(() => {
+      sendResponse({ success: true });
+    });
+    return true;
+  }
+});
+
+// タブ更新時の処理
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status === 'complete' && tab.url) {
+    // Amazon注文履歴ページかチェック
+    if (tab.url.includes('amazon') && tab.url.includes('order-history')) {
+      console.log('Amazon order history page detected');
+
+      // content scriptが既に注入されているかチェック
+      chrome.scripting.executeScript({
+        target: { tabId: tabId },
+        function: () => {
+          return window.amazonExtractorInjected;
+        }
+      }).then((results) => {
+        if (!results[0]?.result) {
+          // content scriptを手動で注入
+          chrome.scripting.executeScript({
+            target: { tabId: tabId },
+            files: ['content.js']
+          });
+        }
+      }).catch((error) => {
+        console.log('Could not inject content script:', error);
+      });
+    }
+  }
+});
+
+// ストレージ変更の監視
+chrome.storage.onChanged.addListener((changes, namespace) => {
+  if (namespace === 'local' && changes.amazonOrders) {
+    console.log('Amazon orders data updated:', changes.amazonOrders.newValue?.length || 0, 'orders');
+  }
+});
+
+// コンテキストメニューのクリックイベント
+if (chrome.contextMenus && chrome.contextMenus.onClicked) {
+  chrome.contextMenus.onClicked.addListener((info, tab) => {
+    if (info.menuItemId === 'extract-amazon-history') {
+      chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        function: () => {
+          // content scriptの抽出関数を呼び出し
+          if (typeof extractPurchaseHistory === 'function') {
+            const orders = extractPurchaseHistory();
+            if (orders.length > 0) {
+              saveToStorage(orders);
+            }
+          }
+        }
+      }).catch((error) => {
+        console.log('Script execution failed:', error);
+      });
+    }
+  });
+}

--- a/chrome-extension-amazon-purchase-history/content.js
+++ b/chrome-extension-amazon-purchase-history/content.js
@@ -1,0 +1,395 @@
+function extractPurchaseHistory() {
+  const orders = [];
+
+  // より具体的なAmazon注文履歴のセレクター
+  const orderSelectors = [
+    // 注文カード全体
+    '.order',
+    '.shipment',
+    '[data-order-id]',
+    '.order-card',
+    '.a-box-group[data-a-accordion-name]',
+    '#orderDetails',
+    '.orderCardDeliveryBox',
+    '.yo-critical-feature',
+    // フォールバック: より一般的なコンテナ
+    '.a-box-group',
+    '.a-section'
+  ];
+
+  let orderElements = [];
+  for (const selector of orderSelectors) {
+    const elements = document.querySelectorAll(selector);
+    if (elements.length > 0) {
+      orderElements = Array.from(elements);
+      console.log(`Found ${elements.length} elements with selector: ${selector}`);
+      break;
+    }
+  }
+
+  // 既存のセレクターでも試してみる
+  if (orderElements.length === 0) {
+    orderElements = Array.from(document.querySelectorAll('div'));
+    console.log('Fallback to all div elements:', orderElements.length);
+  }
+
+  orderElements.forEach((element, index) => {
+    try {
+      // スケルトン要素をスキップ
+      if (element.classList.contains('skeleton') ||
+          element.querySelector('.skeleton') ||
+          element.textContent.trim().length < 10) {
+        return;
+      }
+
+      // 注文日を取得 - より包括的なセレクター
+      let orderDate = '';
+      const dateSelectors = [
+        // 注文日付の一般的なセレクター
+        '.order-date',
+        '.order-info .a-color-secondary',
+        '.delivery-box .a-color-secondary',
+        '[data-test-id="order-date"]',
+        '.a-row .a-color-secondary',
+        '.order-header .a-color-secondary',
+        '.byo-order-details .a-color-secondary',
+        '.shipment-top-row .a-color-secondary',
+        // より広範囲で日付を探す
+        '.a-color-secondary',
+        '.a-color-base'
+      ];
+
+      for (const selector of dateSelectors) {
+        const dateElements = element.querySelectorAll(selector);
+        for (const dateElement of dateElements) {
+          if (dateElement && dateElement.textContent) {
+            const text = dateElement.textContent.trim();
+            // 日付らしきパターンを探す（日本語と英語両対応）
+            const dateMatch = text.match(/(\d{4}年\d{1,2}月\d{1,2}日|\d{1,2}\/\d{1,2}\/\d{4}|\d{4}-\d{1,2}-\d{1,2}|[A-Za-z]+ \d{1,2}, \d{4}|\d{1,2} [A-Za-z]+ \d{4})/);
+            if (dateMatch) {
+              orderDate = dateMatch[1];
+              break;
+            }
+          }
+        }
+        if (orderDate) break;
+      }
+
+      // 注文ID を取得
+      let orderId = '';
+
+      // data-order-id属性から取得
+      const orderIdElement = element.querySelector('[data-order-id]') || element.closest('[data-order-id]');
+      if (orderIdElement) {
+        orderId = orderIdElement.getAttribute('data-order-id') || '';
+      }
+
+      // テキストから注文番号を抽出
+      if (!orderId) {
+        const allText = element.textContent || '';
+        const idMatches = [
+          /(?:注文番号|Order #|注文ID|Order ID)[:\s]*([A-Z0-9-]{10,})/i,
+          /([A-Z0-9]{3}-[A-Z0-9]{7}-[A-Z0-9]{7})/i,  // Amazon注文番号パターン
+          /#([A-Z0-9-]{10,})/i
+        ];
+
+        for (const pattern of idMatches) {
+          const match = allText.match(pattern);
+          if (match) {
+            orderId = match[1];
+            break;
+          }
+        }
+      }
+
+      // 商品情報を取得 - より包括的なセレクター
+      const productSelectors = [
+        // 商品リンク
+        'a[href*="/dp/"]',
+        'a[href*="/gp/product/"]',
+        '.a-link-normal[href*="/dp/"]',
+        '.product-image a',
+        '.a-link-normal',
+        // 商品名のテキスト要素
+        '.a-size-medium.a-link-normal',
+        '.a-size-base-plus',
+        '.a-size-base a',
+        // より一般的なリンク
+        'a[title]',
+        'a img[alt]'
+      ];
+
+      const products = [];
+      const seenProducts = new Set();
+
+      for (const selector of productSelectors) {
+        const productElements = element.querySelectorAll(selector);
+
+        productElements.forEach(productElement => {
+          let productName = '';
+
+          // 商品名の取得方法を複数試す
+          if (productElement.textContent && productElement.textContent.trim().length > 5) {
+            productName = productElement.textContent.trim();
+          } else if (productElement.title) {
+            productName = productElement.title.trim();
+          } else if (productElement.querySelector('img')?.alt) {
+            productName = productElement.querySelector('img').alt.trim();
+          }
+
+          const productUrl = productElement.href || '';
+          const productImage = productElement.querySelector('img')?.src || '';
+
+          // 有効な商品名かチェック
+          if (productName &&
+              productName.length > 5 &&
+              !seenProducts.has(productName) &&
+              !productName.includes('注文内容を表示') &&
+              !productName.includes('詳細を表示') &&
+              !/^[0-9\s¥,]+$/.test(productName)) {
+
+            seenProducts.add(productName);
+            products.push({
+              name: productName,
+              url: productUrl,
+              image: productImage
+            });
+          }
+        });
+
+        if (products.length > 0) break;
+      }
+
+      // 価格情報を取得 - より包括的
+      let price = '';
+      const priceSelectors = [
+        '.a-price .a-price-whole',
+        '.a-price-amount',
+        '.a-size-base.a-color-price',
+        '.a-price',
+        '.price'
+      ];
+
+      for (const selector of priceSelectors) {
+        const priceElement = element.querySelector(selector);
+        if (priceElement && priceElement.textContent) {
+          const priceText = priceElement.textContent.trim();
+          if (priceText.includes('¥') || priceText.includes('$')) {
+            price = priceText;
+            break;
+          }
+        }
+      }
+
+      // テキスト全体から価格を抽出
+      if (!price) {
+        const allText = element.textContent || '';
+        const priceMatch = allText.match(/¥[\d,]+/);
+        if (priceMatch) {
+          price = priceMatch[0];
+        }
+      }
+
+      // 配送状況を取得
+      const statusSelectors = [
+        '.a-color-success',
+        '.a-color-state',
+        '.delivery-box span',
+        '.shipment-status',
+        '.order-status'
+      ];
+
+      let status = '';
+      for (const selector of statusSelectors) {
+        const statusElement = element.querySelector(selector);
+        if (statusElement && statusElement.textContent) {
+          status = statusElement.textContent.trim();
+          break;
+        }
+      }
+
+      // より良いフィルタリング条件
+      const hasValidData = orderId ||
+                          (products.length > 0) ||
+                          (orderDate && price) ||
+                          (element.textContent && element.textContent.length > 50);
+
+      if (hasValidData) {
+        const order = {
+          orderId: orderId || 'N/A',
+          orderDate: orderDate || 'N/A',
+          products: products,
+          price: price,
+          status: status || 'N/A',
+          productCount: products.length,
+          extractedAt: new Date().toISOString()
+        };
+
+        console.log('Adding order:', {
+          ...order,
+          elementText: element.textContent?.substring(0, 200) + '...',
+          elementClass: element.className,
+          elementTag: element.tagName
+        });
+        orders.push(order);
+      }
+    } catch (error) {
+      console.error('Error extracting order data:', error);
+    }
+  });
+
+  return orders;
+}
+
+function saveToStorage(data) {
+  chrome.storage.local.get(['amazonOrders'], function(result) {
+    const existingOrders = result.amazonOrders || [];
+    const allOrders = [...existingOrders, ...data];
+
+    // 重複削除の改善：注文IDがある場合はそれで、ない場合は商品情報で判定
+    const uniqueOrders = allOrders.filter((order, index, self) => {
+      if (order.orderId && order.orderId.trim()) {
+        // 注文IDがある場合はそれで重複チェック
+        return index === self.findIndex(o => o.orderId === order.orderId);
+      } else {
+        // 注文IDがない場合は、日付と商品の組み合わせで重複チェック
+        const orderKey = `${order.orderDate}_${order.products.map(p => p.name).join('_')}`;
+        const existingKey = `${self[index].orderDate}_${self[index].products.map(p => p.name).join('_')}`;
+        return index === self.findIndex(o => {
+          const oKey = `${o.orderDate}_${o.products.map(p => p.name).join('_')}`;
+          return oKey === orderKey;
+        });
+      }
+    });
+
+    console.log('Data to save:', data.length, 'orders');
+    console.log('Existing orders:', existingOrders.length);
+    console.log('After deduplication:', uniqueOrders.length);
+
+    chrome.storage.local.set({
+      amazonOrders: uniqueOrders,
+      lastExtracted: new Date().toISOString()
+    }, function() {
+      console.log('Purchase history saved:', uniqueOrders.length, 'orders');
+
+      // ポップアップに結果を送信
+      chrome.runtime.sendMessage({
+        action: 'extraction_complete',
+        ordersCount: data.length,
+        totalOrders: uniqueOrders.length
+      }).catch(() => {
+        // ポップアップが開いていない場合はエラーを無視
+        console.log('Could not send message to popup');
+      });
+    });
+  });
+}
+
+// 動的コンテンツの読み込み待機
+function waitForContent(maxAttempts = 10, interval = 1000) {
+  return new Promise((resolve) => {
+    let attempts = 0;
+
+    const check = () => {
+      attempts++;
+      console.log(`Attempt ${attempts}: Checking for content...`);
+
+      // スケルトンではない実際のコンテンツがあるかチェック
+      const nonSkeletonElements = document.querySelectorAll('div:not(.skeleton)');
+      const hasRealContent = Array.from(nonSkeletonElements).some(el =>
+        el.textContent &&
+        el.textContent.trim().length > 50 &&
+        !el.classList.contains('skeleton') &&
+        !el.querySelector('.skeleton')
+      );
+
+      // Amazon特有の要素がロードされているかチェック
+      const hasAmazonContent = document.querySelector('.a-price') ||
+                              document.querySelector('[data-order-id]') ||
+                              document.querySelector('.order') ||
+                              document.querySelector('.shipment') ||
+                              document.querySelectorAll('a[href*="/dp/"]').length > 0;
+
+      console.log('Content check:', { hasRealContent, hasAmazonContent, attempts });
+
+      if ((hasRealContent && hasAmazonContent) || attempts >= maxAttempts) {
+        console.log('Content ready or max attempts reached');
+        resolve();
+      } else {
+        setTimeout(check, interval);
+      }
+    };
+
+    check();
+  });
+}
+
+// 改良された抽出実行関数
+async function runExtraction() {
+  console.log('Starting Amazon purchase history extraction...');
+
+  // 動的コンテンツの読み込み待機
+  await waitForContent();
+
+  console.log('Content loaded, starting extraction...');
+  const orders = extractPurchaseHistory();
+
+  console.log(`Extracted ${orders.length} orders`);
+  orders.forEach((order, index) => {
+    console.log(`Order ${index + 1}:`, {
+      orderId: order.orderId,
+      date: order.orderDate,
+      productCount: order.productCount,
+      price: order.price,
+      products: order.products.map(p => p.name.substring(0, 50))
+    });
+  });
+
+  if (orders.length > 0) {
+    saveToStorage(orders);
+  } else {
+    console.log('No orders found. Page might not be fully loaded or structure changed.');
+    // デバッグ情報を出力
+    console.log('Page analysis:');
+    console.log('- Total divs:', document.querySelectorAll('div').length);
+    console.log('- Skeleton elements:', document.querySelectorAll('.skeleton').length);
+    console.log('- Amazon links:', document.querySelectorAll('a[href*="/dp/"]').length);
+    console.log('- Price elements:', document.querySelectorAll('.a-price').length);
+  }
+}
+
+// 注入済みマーカー
+window.amazonExtractorInjected = true;
+
+// ページ読み込み完了後に実行
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', runExtraction);
+} else {
+  runExtraction();
+}
+
+// メッセージリスナー
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+  if (request.action === 'extract_now') {
+    console.log('Manual extraction triggered');
+    runExtraction().then(() => {
+      const orders = extractPurchaseHistory();
+      sendResponse({success: true, ordersCount: orders.length});
+    });
+    return true; // 非同期レスポンスを示す
+  }
+});
+
+// ページ変更の監視
+let lastUrl = location.href;
+new MutationObserver(() => {
+  const url = location.href;
+  if (url !== lastUrl) {
+    lastUrl = url;
+    console.log('URL changed to:', url);
+    if (url.includes('order-history') || url.includes('your-orders')) {
+      console.log('Amazon order history page detected, running extraction...');
+      setTimeout(runExtraction, 2000);
+    }
+  }
+}).observe(document, {subtree: true, childList: true});

--- a/chrome-extension-amazon-purchase-history/manifest.json
+++ b/chrome-extension-amazon-purchase-history/manifest.json
@@ -1,0 +1,42 @@
+{
+  "manifest_version": 3,
+  "name": "Amazon Purchase History Extractor",
+  "version": "1.0",
+  "description": "Chrome extension to extract Amazon purchase history",
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "storage",
+    "contextMenus"
+  ],
+  "host_permissions": [
+    "https://*.amazon.com/*",
+    "https://*.amazon.co.jp/*",
+    "https://*.amazon.de/*",
+    "https://*.amazon.fr/*",
+    "https://*.amazon.it/*",
+    "https://*.amazon.es/*",
+    "https://*.amazon.co.uk/*"
+  ],
+  "content_scripts": [
+    {
+      "matches": [
+        "https://*.amazon.com/gp/your-account/order-history*",
+        "https://*.amazon.co.jp/gp/your-account/order-history*",
+        "https://*.amazon.de/gp/your-account/order-history*",
+        "https://*.amazon.fr/gp/your-account/order-history*",
+        "https://*.amazon.it/gp/your-account/order-history*",
+        "https://*.amazon.es/gp/your-account/order-history*",
+        "https://*.amazon.co.uk/gp/your-account/order-history*"
+      ],
+      "js": ["content.js"]
+    }
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Amazon Purchase History Extractor"
+  }
+}

--- a/chrome-extension-amazon-purchase-history/popup.css
+++ b/chrome-extension-amazon-purchase-history/popup.css
@@ -1,0 +1,149 @@
+body {
+  width: 400px;
+  min-height: 500px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  margin: 0;
+  padding: 0;
+  background: #f5f5f5;
+}
+
+.container {
+  padding: 20px;
+  background: white;
+  margin: 0;
+}
+
+h1 {
+  color: #232f3e;
+  font-size: 18px;
+  margin: 0 0 20px 0;
+  text-align: center;
+  border-bottom: 2px solid #ff9900;
+  padding-bottom: 10px;
+}
+
+h3 {
+  color: #232f3e;
+  font-size: 14px;
+  margin: 15px 0 10px 0;
+}
+
+.status-section,
+.control-section,
+.stats-section,
+.instructions {
+  margin-bottom: 20px;
+  padding: 15px;
+  background: #f9f9f9;
+  border-radius: 5px;
+  border-left: 4px solid #ff9900;
+}
+
+.control-section {
+  text-align: center;
+}
+
+button {
+  padding: 10px 15px;
+  margin: 5px;
+  border: none;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background-color 0.3s;
+  min-width: 120px;
+}
+
+.primary-btn {
+  background: #ff9900;
+  color: white;
+}
+
+.primary-btn:hover {
+  background: #e88900;
+}
+
+.primary-btn:disabled {
+  background: #cccccc;
+  cursor: not-allowed;
+}
+
+.secondary-btn {
+  background: #0066c0;
+  color: white;
+}
+
+.secondary-btn:hover {
+  background: #005bb5;
+}
+
+.danger-btn {
+  background: #d13212;
+  color: white;
+}
+
+.danger-btn:hover {
+  background: #b02a0a;
+}
+
+.stats-section p {
+  margin: 8px 0;
+}
+
+.data-section {
+  max-height: 300px;
+  overflow-y: auto;
+  border: 1px solid #ddd;
+  padding: 10px;
+  background: white;
+  border-radius: 4px;
+}
+
+.order-item {
+  border: 1px solid #e0e0e0;
+  margin: 10px 0;
+  padding: 10px;
+  border-radius: 4px;
+  background: #fafafa;
+}
+
+.order-header {
+  font-weight: bold;
+  color: #232f3e;
+  margin-bottom: 5px;
+}
+
+.product-item {
+  margin: 5px 0;
+  padding: 5px;
+  background: white;
+  border-radius: 3px;
+  font-size: 12px;
+}
+
+.instructions ol {
+  padding-left: 20px;
+}
+
+.instructions li {
+  margin: 5px 0;
+  font-size: 12px;
+}
+
+#current-url {
+  font-size: 12px;
+  word-break: break-all;
+}
+
+.loading {
+  color: #ff9900;
+}
+
+.success {
+  color: #067d62;
+}
+
+.error {
+  color: #d13212;
+}

--- a/chrome-extension-amazon-purchase-history/popup.html
+++ b/chrome-extension-amazon-purchase-history/popup.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Amazon Purchase History Extractor</title>
+    <link rel="stylesheet" href="popup.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Amazon購入履歴抽出</h1>
+
+        <div class="status-section">
+            <p><strong>現在のページ:</strong> <span id="current-url">確認中...</span></p>
+            <p><strong>抽出状況:</strong> <span id="extraction-status">待機中</span></p>
+        </div>
+
+        <div class="control-section">
+            <button id="extract-btn" class="primary-btn">購入履歴を抽出</button>
+            <button id="view-data-btn" class="secondary-btn">抽出データを表示</button>
+            <button id="export-btn" class="secondary-btn">JSONでエクスポート</button>
+            <button id="clear-btn" class="danger-btn">データをクリア</button>
+        </div>
+
+        <div class="stats-section">
+            <h3>統計情報</h3>
+            <p><strong>保存済み注文数:</strong> <span id="orders-count">0</span></p>
+            <p><strong>最後の抽出:</strong> <span id="last-extracted">未実行</span></p>
+        </div>
+
+        <div class="data-section" id="data-section" style="display: none;">
+            <h3>抽出データ</h3>
+            <div id="orders-list"></div>
+        </div>
+
+        <div class="instructions">
+            <h3>使用方法</h3>
+            <ol>
+                <li>Amazonの注文履歴ページに移動</li>
+                <li>「購入履歴を抽出」ボタンをクリック</li>
+                <li>すべてのページを閲覧して履歴を収集</li>
+                <li>「抽出データを表示」で結果確認</li>
+            </ol>
+        </div>
+    </div>
+    <script src="popup.js"></script>
+</body>
+</html>

--- a/chrome-extension-amazon-purchase-history/popup.js
+++ b/chrome-extension-amazon-purchase-history/popup.js
@@ -1,0 +1,321 @@
+document.addEventListener('DOMContentLoaded', function() {
+    updateStats();
+    checkCurrentPage();
+
+    // 現在のページ情報を取得
+    function checkCurrentPage() {
+        chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+            const currentTab = tabs[0];
+            const url = currentTab.url;
+            document.getElementById('current-url').textContent = url;
+
+            if (url.includes('amazon') && url.includes('order-history')) {
+                document.getElementById('extraction-status').textContent = 'Amazon注文履歴ページ検出';
+                document.getElementById('extraction-status').className = 'success';
+            } else if (url.includes('amazon')) {
+                document.getElementById('extraction-status').textContent = 'Amazonサイト検出（注文履歴ページに移動してください）';
+                document.getElementById('extraction-status').className = 'loading';
+            } else {
+                document.getElementById('extraction-status').textContent = 'Amazonサイトではありません';
+                document.getElementById('extraction-status').className = 'error';
+            }
+        });
+    }
+
+    // 統計情報を更新
+    function updateStats() {
+        chrome.storage.local.get(['amazonOrders', 'lastExtracted'], function(result) {
+            const orders = result.amazonOrders || [];
+            const lastExtracted = result.lastExtracted;
+
+            document.getElementById('orders-count').textContent = orders.length;
+
+            if (lastExtracted) {
+                const date = new Date(lastExtracted);
+                document.getElementById('last-extracted').textContent =
+                    date.toLocaleDateString('ja-JP') + ' ' + date.toLocaleTimeString('ja-JP');
+            }
+        });
+    }
+
+    // 購入履歴抽出ボタン
+    document.getElementById('extract-btn').addEventListener('click', function() {
+        const button = this;
+        button.disabled = true;
+        button.textContent = '抽出中...';
+
+        chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+            const currentTab = tabs[0];
+
+            if (!currentTab.url.includes('amazon')) {
+                alert('Amazonサイトで実行してください');
+                button.disabled = false;
+                button.textContent = '購入履歴を抽出';
+                return;
+            }
+
+            chrome.scripting.executeScript({
+                target: {tabId: currentTab.id},
+                function: extractPurchaseHistoryFromPage
+            }, function(results) {
+                if (chrome.runtime.lastError) {
+                    console.error(chrome.runtime.lastError);
+                    alert('抽出に失敗しました: ' + chrome.runtime.lastError.message);
+                } else {
+                    console.log('Extraction completed');
+                }
+
+                button.disabled = false;
+                button.textContent = '購入履歴を抽出';
+                updateStats();
+            });
+        });
+    });
+
+    // データ表示ボタン
+    document.getElementById('view-data-btn').addEventListener('click', function() {
+        const dataSection = document.getElementById('data-section');
+        const ordersList = document.getElementById('orders-list');
+
+        if (dataSection.style.display === 'none') {
+            chrome.storage.local.get(['amazonOrders'], function(result) {
+                const orders = result.amazonOrders || [];
+
+                if (orders.length === 0) {
+                    ordersList.innerHTML = '<p>抽出されたデータがありません</p>';
+                } else {
+                    ordersList.innerHTML = orders.map(order => `
+                        <div class="order-item">
+                            <div class="order-header">
+                                注文ID: ${order.orderId || 'N/A'} |
+                                日付: ${order.orderDate || 'N/A'}
+                            </div>
+                            <div>価格: ${order.price || 'N/A'}</div>
+                            <div>状況: ${order.status || 'N/A'}</div>
+                            <div>商品数: ${order.products.length}</div>
+                            ${order.products.map(product => `
+                                <div class="product-item">${product.name}</div>
+                            `).join('')}
+                        </div>
+                    `).join('');
+                }
+
+                dataSection.style.display = 'block';
+                this.textContent = 'データを隠す';
+            });
+        } else {
+            dataSection.style.display = 'none';
+            this.textContent = '抽出データを表示';
+        }
+    });
+
+    // エクスポートボタン
+    document.getElementById('export-btn').addEventListener('click', function() {
+        chrome.storage.local.get(['amazonOrders'], function(result) {
+            const orders = result.amazonOrders || [];
+
+            if (orders.length === 0) {
+                alert('抽出されたデータがありません');
+                return;
+            }
+
+            const dataStr = JSON.stringify(orders, null, 2);
+            const dataBlob = new Blob([dataStr], {type: 'application/json'});
+            const url = URL.createObjectURL(dataBlob);
+
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = `amazon-purchase-history-${new Date().toISOString().split('T')[0]}.json`;
+            link.click();
+
+            URL.revokeObjectURL(url);
+        });
+    });
+
+    // データクリアボタン
+    document.getElementById('clear-btn').addEventListener('click', function() {
+        if (confirm('すべての抽出データを削除しますか？')) {
+            chrome.storage.local.clear(function() {
+                alert('データをクリアしました');
+                updateStats();
+                document.getElementById('data-section').style.display = 'none';
+                document.getElementById('view-data-btn').textContent = '抽出データを表示';
+            });
+        }
+    });
+
+    // メッセージリスナー
+    chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+        if (request.action === 'extraction_complete') {
+            updateStats();
+            document.getElementById('extraction-status').textContent =
+                `抽出完了: ${request.ordersCount}件の新しい注文`;
+            document.getElementById('extraction-status').className = 'success';
+        }
+    });
+});
+
+// ページから購入履歴を抽出する関数（content scriptに注入）
+function extractPurchaseHistoryFromPage() {
+    function extractPurchaseHistory() {
+        const orders = [];
+
+        // Amazon の注文履歴ページから情報を抽出
+        const orderElements = document.querySelectorAll('[data-order-id], .order-card, .a-box-group, .shipment, .order, .order-info');
+
+        orderElements.forEach((element, index) => {
+            try {
+                // 注文日を取得 - より包括的なセレクター
+                let orderDate = '';
+                const dateSelectors = [
+                    '.order-info .a-color-secondary',
+                    '.delivery-box .a-color-secondary',
+                    '[data-test-id="order-date"]',
+                    '.a-row .a-color-secondary',
+                    '.order-header .a-color-secondary',
+                    '.byo-order-details .a-color-secondary',
+                    '.shipment-top-row .a-color-secondary'
+                ];
+
+                for (const selector of dateSelectors) {
+                    const dateElement = element.querySelector(selector);
+                    if (dateElement && dateElement.textContent) {
+                        const text = dateElement.textContent.trim();
+                        // 日付らしきパターンを探す
+                        const dateMatch = text.match(/(\d{4}年\d{1,2}月\d{1,2}日|\d{1,2}\/\d{1,2}\/\d{4}|\d{4}-\d{1,2}-\d{1,2}|[A-Za-z]+ \d{1,2}, \d{4})/);
+                        if (dateMatch) {
+                            orderDate = dateMatch[1];
+                            break;
+                        }
+                    }
+                }
+
+                // 注文ID を取得 - より包括的な検索
+                let orderId = '';
+                const orderIdSelectors = [
+                    '[data-order-id]',
+                    '.byo-order-details .a-color-secondary',
+                    '.order-info .a-color-secondary',
+                    '.order-header .a-color-secondary'
+                ];
+
+                // data-order-id属性から取得
+                const orderIdElement = element.querySelector('[data-order-id]');
+                if (orderIdElement) {
+                    orderId = orderIdElement.getAttribute('data-order-id') || '';
+                }
+
+                // テキストから注文番号を抽出
+                if (!orderId) {
+                    for (const selector of orderIdSelectors) {
+                        const idElement = element.querySelector(selector);
+                        if (idElement && idElement.textContent) {
+                            const text = idElement.textContent;
+                            const idMatch = text.match(/(?:注文番号|Order #|注文ID)[:\s]*([A-Z0-9-]{10,})/i);
+                            if (idMatch) {
+                                orderId = idMatch[1];
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                // 商品情報を取得
+                const productElements = element.querySelectorAll('.a-row .a-link-normal, .product-image a, .a-link-normal[href*="/dp/"], .item-view-container');
+                const products = [];
+
+                productElements.forEach(productElement => {
+                    const productName = productElement.textContent?.trim() ||
+                                       productElement.querySelector('img')?.alt || '';
+                    const productUrl = productElement.href || '';
+                    const productImage = productElement.querySelector('img')?.src || '';
+
+                    if (productName && productName.length > 0) {
+                        products.push({
+                            name: productName,
+                            url: productUrl,
+                            image: productImage
+                        });
+                    }
+                });
+
+                // 価格情報を取得
+                const priceElement = element.querySelector('.a-price .a-price-whole, .a-price-amount, .a-size-base.a-color-price');
+                const price = priceElement ? priceElement.textContent.trim() : '';
+
+                // 配送状況を取得
+                const statusElement = element.querySelector('.a-color-success, .a-color-state, .delivery-box span');
+                const status = statusElement ? statusElement.textContent.trim() : '';
+
+                if (orderId || products.length > 0 || orderDate) {
+                    orders.push({
+                        orderId: orderId,
+                        orderDate: orderDate,
+                        products: products,
+                        price: price,
+                        status: status,
+                        extractedAt: new Date().toISOString()
+                    });
+                }
+            } catch (error) {
+                console.error('Error extracting order data:', error);
+            }
+        });
+
+        return orders;
+    }
+
+    function saveToStorage(data) {
+        chrome.storage.local.get(['amazonOrders'], function(result) {
+            const existingOrders = result.amazonOrders || [];
+            const allOrders = [...existingOrders, ...data];
+
+            // 重複削除の改善：注文IDがある場合はそれで、ない場合は商品情報で判定
+            const uniqueOrders = allOrders.filter((order, index, self) => {
+                if (order.orderId && order.orderId.trim()) {
+                    // 注文IDがある場合はそれで重複チェック
+                    return index === self.findIndex(o => o.orderId === order.orderId);
+                } else {
+                    // 注文IDがない場合は、日付と商品の組み合わせで重複チェック
+                    const orderKey = `${order.orderDate}_${order.products.map(p => p.name).join('_')}`;
+                    return index === self.findIndex(o => {
+                        const oKey = `${o.orderDate}_${o.products.map(p => p.name).join('_')}`;
+                        return oKey === orderKey;
+                    });
+                }
+            });
+
+            console.log('Data to save:', data.length, 'orders');
+            console.log('Existing orders:', existingOrders.length);
+            console.log('After deduplication:', uniqueOrders.length);
+
+            chrome.storage.local.set({
+                amazonOrders: uniqueOrders,
+                lastExtracted: new Date().toISOString()
+            }, function() {
+                console.log('Purchase history saved:', uniqueOrders.length, 'orders');
+
+                // ポップアップに結果を送信
+                chrome.runtime.sendMessage({
+                    action: 'extraction_complete',
+                    ordersCount: data.length,
+                    totalOrders: uniqueOrders.length
+                }).catch(() => {
+                    console.log('Could not send message');
+                });
+            });
+        });
+    }
+
+    // 抽出実行
+    const orders = extractPurchaseHistory();
+    console.log('Extracted orders:', orders.length);
+
+    if (orders.length > 0) {
+        saveToStorage(orders);
+        return { success: true, ordersCount: orders.length };
+    } else {
+        console.log('No orders found on this page');
+        return { success: false, message: 'このページで注文が見つかりませんでした' };
+    }
+}


### PR DESCRIPTION
## 概要
Amazon購入履歴を自動抽出するChrome拡張機能を実装しました。実際のAmazon注文履歴ページの構造に基づいて抽出ロジックを大幅に改善し、より正確なデータ抽出を可能にしました。

## 主な機能
- Amazon注文履歴ページからの自動データ抽出
- 複数のAmazonドメインに対応（.com, .co.jp, .de, .fr, .it, .es, .co.uk）
- 注文ID、注文日、商品情報、価格、配送状況の抽出
- JSONファイルとしてのデータエクスポート
- 重複データの自動除去
- リアルタイムでの抽出状況表示

## 技術的改善点
- **包括的なセレクター**: Amazon注文履歴の様々な構造に対応する複数のCSSセレクター
- **スケルトン要素の除外**: ローディング中のプレースホルダー要素を適切にスキップ
- **動的コンテンツ対応**: `waitForContent()`関数でページの完全読み込みを待機
- **商品名フィルタリング**: UI要素（「注文内容を表示」など）の除外と重複防止
- **正規表現による価格抽出**: テキスト全体から¥価格パターンを抽出
- **Amazon注文ID認識**: Amazon固有の注文番号パターンに対応
- **詳細なデバッグログ**: 抽出プロセスの可視化とトラブルシューティング支援

## ファイル構成
- `manifest.json`: 拡張機能の設定とパーミッション
- `content.js`: Amazon ページでの抽出処理（大幅改善済み）
- `popup.html/css/js`: ユーザーインターフェース
- `background.js`: バックグラウンド処理とイベント管理
- `README.md`: 詳細な使用方法とトラブルシューティング

## テスト計画
- [ ] Amazon.co.jpでの注文履歴抽出テスト
- [ ] 複数ページにわたる履歴の抽出テスト
- [ ] 異なる商品タイプ（書籍、電子機器、衣類など）での抽出テスト
- [ ] データエクスポート機能のテスト
- [ ] 重複除去機能のテスト

🤖 Generated with [Claude Code](https://claude.ai/code)