### PR TITLE
refactor: remove RECLAIM_PROVIDER_ID environment variable fallback

### DIFF
--- a/server/src/reclaim.ts
+++ b/server/src/reclaim.ts
@@ -19,7 +19,7 @@ export async function createProofRequest(params: {
   providerId?: string
   context?: Record<string, any>
 }) {
-  const providerId = params.providerId || process.env.RECLAIM_PROVIDER_ID
+  const providerId = params.providerId
   if (!providerId) {
     // For mock, simply return a fake URL the UI can display
     return {


### PR DESCRIPTION
## Summary
- Removed the environment variable fallback for `RECLAIM_PROVIDER_ID` in the Reclaim integration
- Simplified the provider ID logic to only use the explicitly passed parameter

## Changes
- Modified `server/src/reclaim.ts` to remove `process.env.RECLAIM_PROVIDER_ID` fallback
- The `createProofRequest` function now only uses `params.providerId` without environment variable fallback

## Technical Details
The previous implementation would fall back to the `RECLAIM_PROVIDER_ID` environment variable if no provider ID was explicitly passed. This fallback has been removed as it is no longer needed, simplifying the code and making the provider ID requirement more explicit.

## Testing
- Verify that the Reclaim integration still works correctly in mock mode
- Ensure that provider ID is properly passed when needed
- Check that the application handles missing provider ID appropriately

## Notes
This change makes the provider ID handling more explicit and removes unnecessary environment variable dependencies.